### PR TITLE
ci: Add workflow for deployment to Render

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,85 @@
+name: Deploy to Render and Update GitHub Deployment
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create GitHub deployment
+        id: deployment
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/${{ github.repository }}/deployments
+          ref: ${{ github.sha }}
+          required_contexts: []
+          environment: production
+          auto_merge: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger new deploy on Render
+        id: render_deploy
+        run: |
+          echo "Triggering new deployment on Render..."
+          response=$(curl -s -X POST https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID }}/deploys \
+            -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json")
+          deploy_id=$(echo "$response" | jq -r '.id')
+          echo "Render deploy ID: $deploy_id"
+          echo "deploy_id=$deploy_id" >> $GITHUB_ENV
+
+      - name: Poll deployment status on Render
+        run: |
+          echo "Polling Render deployment status..."
+          for i in {1..30}; do
+            status_response=$(curl -s -X GET https://api.render.com/v1/deploys/$deploy_id \
+              -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
+              -H "Accept: application/json")
+            deploy_status=$(echo "$status_response" | jq -r '.status')
+
+            echo "Current deploy status: $deploy_status"
+
+            if [[ "$deploy_status" == "live" ]]; then
+              echo "Deployment succeeded!"
+              echo "render_deploy_status=success" >> $GITHUB_ENV
+              exit 0
+            elif [[ "$deploy_status" == "failed" ]]; then
+              echo "Deployment failed!"
+              echo "render_deploy_status=failure" >> $GITHUB_ENV
+              exit 1
+            fi
+
+            echo "Waiting 10 seconds before next check..."
+            sleep 10
+          done
+
+          echo "Deployment polling timeout!"
+          echo "render_deploy_status=failure" >> $GITHUB_ENV
+          exit 1
+
+      - name: Set GitHub deployment status to success
+        if: success()
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/${{ github.repository }}/deployments/${{ steps.deployment.outputs.id }}/statuses
+          state: success
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set GitHub deployment status to failure
+        if: failure()
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/${{ github.repository }}/deployments/${{ steps.deployment.outputs.id }}/statuses
+          state: failure
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,11 @@ jobs:
             -H "Accept: application/json" \
             -H "Content-Type: application/json")
           deploy_id=$(echo "$response" | jq -r '.id')
+          if [[ -z "$deploy_id" || "$deploy_id" == "null" ]]; then
+            echo "Error: Failed to retrieve a valid deploy ID from Render API response."
+            echo "Response: $response"
+            exit 1
+          fi
           echo "Render deploy ID: $deploy_id"
           echo "deploy_id=$deploy_id" >> $GITHUB_ENV
 
@@ -41,10 +46,22 @@ jobs:
         run: |
           echo "Polling Render deployment status..."
           for i in {1..30}; do
-            status_response=$(curl -s -X GET https://api.render.com/v1/deploys/$deploy_id \
+            status_response=$(curl -s -w "%{http_code}" -X GET https://api.render.com/v1/deploys/$deploy_id \
               -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
               -H "Accept: application/json")
-            deploy_status=$(echo "$status_response" | jq -r '.status')
+            http_status=$(echo "$status_response" | tail -c 4)
+            response_body=$(echo "$status_response" | head -c -4)
+            if [[ "$http_status" -ne 200 ]]; then
+              echo "Error: Received HTTP status $http_status from Render API."
+              echo "render_deploy_status=failure" >> $GITHUB_ENV
+              exit 1
+            fi
+            deploy_status=$(echo "$response_body" | jq -r '.status' 2>/dev/null)
+            if [[ -z "$deploy_status" || "$deploy_status" == "null" ]]; then
+              echo "Error: Invalid or missing 'status' field in API response."
+              echo "render_deploy_status=failure" >> $GITHUB_ENV
+              exit 1
+            fi
 
             echo "Current deploy status: $deploy_status"
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate deployments to Render and update the deployment status on GitHub. The workflow handles deployment initiation, status polling, and updating the deployment status based on the result.

### New GitHub Actions Workflow for Deployment:
* Added `.github/workflows/deploy.yml` to define a workflow that triggers on pushes to the `main` branch. The workflow includes steps to:
  - Check out the repository code.  
  - Create a GitHub deployment using the `octokit/request-action`.  
  - Trigger a new deployment on Render via the Render API.  
  - Poll the deployment status on Render, with retries and timeout handling.  
  - Update the GitHub deployment status to `success` or `failure` based on the Render deployment result.