### PR TITLE
feat(admin): add filtering to audits index page

### DIFF
--- a/app/controllers/spree/admin/audits_controller.rb
+++ b/app/controllers/spree/admin/audits_controller.rb
@@ -2,7 +2,16 @@ module Spree
   module Admin
     class AuditsController < Spree::Admin::BaseController
       def index
-        @audits = Audited::Audit.order(created_at: :desc).page(params[:page]).per(25)
+        audits_scope = Audited::Audit.order(created_at: :desc)
+
+        if params[:q].present?
+          audits_scope = audits_scope.where(
+            auditable_id: params[:q][:auditable_id_eq],
+            auditable_type: params[:q][:auditable_type_eq]
+          )
+        end
+
+        @audits = audits_scope.page(params[:page]).per(21)
       end
     end
   end


### PR DESCRIPTION
This pull request introduces a change to the `AuditsController` in the Spree Admin module to enhance filtering and pagination for audit records.

### Improvements to audit filtering and pagination:

* [`app/controllers/spree/admin/audits_controller.rb`](diffhunk://#diff-b6084692c876a39f2f8d8e334f422c2e527f45d984d782b3518cd557e46cb7bbL5-R14): Updated the `index` action to support filtering by `auditable_id` and `auditable_type` when query parameters are provided. Additionally, the pagination size was adjusted from 25 to 21 records per page.